### PR TITLE
feat: 계좌 거래 내역 조회 요청

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     // Spring Boot 액추에이터 스타터 (옵션, 모니터링 용도)
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // 모델 매퍼
+    implementation 'org.modelmapper:modelmapper:3.1.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/ssok/bank/common/constant/CurrencyCode.java
+++ b/src/main/java/kr/ssok/bank/common/constant/CurrencyCode.java
@@ -7,9 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum CurrencyCode {
     // 원화
-    WON(1,"WON"),
+    WON(0,"WON"),
     // 달러화
-    DOLLAR(2,"DOLLAR");
+    DOLLAR(1,"DOLLAR");
 
     private final int idx;
     private final String value;

--- a/src/main/java/kr/ssok/bank/common/constant/TransferTypeCode.java
+++ b/src/main/java/kr/ssok/bank/common/constant/TransferTypeCode.java
@@ -7,9 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum TransferTypeCode {
     // 입금
-    DEPOSIT(1,"DEPOSIT"),
+    DEPOSIT(0,"DEPOSIT"),
     // 출금
-    WITHDRAW(2,"WITHDRAW");
+    WITHDRAW(1,"WITHDRAW");
 
     private final int idx;
     private final String value;

--- a/src/main/java/kr/ssok/bank/domain/account/dto/AccountTransferHistoryRequestDTO.java
+++ b/src/main/java/kr/ssok/bank/domain/account/dto/AccountTransferHistoryRequestDTO.java
@@ -1,0 +1,12 @@
+package kr.ssok.bank.domain.account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AccountTransferHistoryRequestDTO {
+    private String account;
+}

--- a/src/main/java/kr/ssok/bank/domain/account/dto/AccountTransferHistoryResponseDTO.java
+++ b/src/main/java/kr/ssok/bank/domain/account/dto/AccountTransferHistoryResponseDTO.java
@@ -1,0 +1,23 @@
+package kr.ssok.bank.domain.account.dto;
+
+import kr.ssok.bank.common.constant.CurrencyCode;
+import kr.ssok.bank.common.constant.TransferTypeCode;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccountTransferHistoryResponseDTO {
+
+    private TransferTypeCode transferType;
+    private String account;
+    private String counterpartAccount;
+    private Long transferAmount;
+    private CurrencyCode currencyCode;
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/kr/ssok/bank/domain/transfer/entity/TransferHistory.java
+++ b/src/main/java/kr/ssok/bank/domain/transfer/entity/TransferHistory.java
@@ -7,8 +7,6 @@ import kr.ssok.bank.common.entity.TimeStamp;
 import kr.ssok.bank.domain.account.entity.Account;
 import lombok.*;
 
-import static kr.ssok.bank.common.constant.CurrencyCode.WON;
-
 @Entity
 @Getter
 @Builder
@@ -29,6 +27,7 @@ public class TransferHistory extends TimeStamp {
     private String transactionId;
 
     // 송금 타입
+    @Enumerated(EnumType.STRING)
     @Column(name = "transfer_type", nullable = false)
     private TransferTypeCode transferTypeCode;
 
@@ -43,7 +42,7 @@ public class TransferHistory extends TimeStamp {
     // 통화 코드
     @Enumerated(EnumType.STRING)
     @Column(name = "currency_code", nullable = false)
-    private CurrencyCode currencyCode = WON;
+    private CurrencyCode currencyCode = CurrencyCode.WON;
 
     // 송금 후 잔액
     @Column(name = "balance_after", nullable = false)

--- a/src/main/java/kr/ssok/bank/domain/transfer/service/TransferServiceImpl.java
+++ b/src/main/java/kr/ssok/bank/domain/transfer/service/TransferServiceImpl.java
@@ -19,7 +19,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 @Service
 @RequiredArgsConstructor
-public class TransferServiceImpl {
+public class TransferServiceImpl implements TransferService{
 
     private Map<String, ReentrantLock> lockMap = new HashMap<>();
 
@@ -46,6 +46,8 @@ public class TransferServiceImpl {
                 .transferAmount(dto.getTransferAmount())  // 송금 금액 기록
                 .balanceAfter(withdrawAccount.getBalance())  // 출금 후 잔액 기록
                 .transferTypeCode(TransferTypeCode.WITHDRAW)
+                .currencyCode(dto.getCurrencyCode())
+                .transactionId(dto.getTransactionId())
                 .build();
         transferRepository.save(history);
 
@@ -91,7 +93,10 @@ public class TransferServiceImpl {
                 .transferAmount(dto.getTransferAmount())  // 송금 금액 기록
                 .balanceAfter(depositAccount.getBalance())  // 입금 후 잔액 기록
                 .transferTypeCode(TransferTypeCode.DEPOSIT)
+                .currencyCode(dto.getCurrencyCode())
+                .transactionId(dto.getTransactionId())
                 .build();
+
         transferRepository.save(history);
 
         // 4. 변경된 계좌 저장


### PR DESCRIPTION
## #️⃣ Issue Number

close #29

## 📝 요약(Summary)

- 계좌 컨트롤러에 계좌 거래 내역 조회 요청 기능이 추가되었습니다.
- BankCode와 CurrencyCode의 value값이 인덱스 번호와 동일하게 0부터 시작합니다.
- Postman으로 입금 이체, 송금이체, 거래내역 API 테스트를 마쳤습니다.
