### PR TITLE
feat: 카프카 메세지 타임아웃 방지 로직 추가(#63, SCRUM-165)

### DIFF
--- a/src/main/java/kr/ssok/bank/common/constant/FailureStatusCode.java
+++ b/src/main/java/kr/ssok/bank/common/constant/FailureStatusCode.java
@@ -41,6 +41,7 @@ public enum FailureStatusCode implements BaseCode {
     // 거래 관련 에러
     TRANSACTION_NOT_EXISTS(HttpStatus.BAD_REQUEST, "TRANSACTION4002", "거래 내역이 존재하지 않습니다."),
     TRANSACTION_CREATE_FAILED(HttpStatus.BAD_REQUEST, "TRANSACTION4003", "거래 내역 생성에 실패하였습니다."),
+    REQUEST_TIMEOUT(HttpStatus.BAD_REQUEST, "TRANSACTION4004", "거래 내역 처리 중 타임 아웃이 발생하였습니다."),
 
     // 송금 관련 에러
     TRANSFER_FAILED(HttpStatus.BAD_REQUEST, "TRANSFER4001", "송금에 실패하였습니다."),

--- a/src/main/java/kr/ssok/bank/domain/transfer/dto/TransferDepositRequestDTO.java
+++ b/src/main/java/kr/ssok/bank/domain/transfer/dto/TransferDepositRequestDTO.java
@@ -13,4 +13,5 @@ public class TransferDepositRequestDTO {
     private CurrencyCode currencyCode; // 통화 코드
     private String counterAccount; // 출금 계좌
     private BankCode counterBankCode; // 출금 은행 코드
+    private Long messageCreatedAt; // 메세지 생성 시간
 }

--- a/src/main/java/kr/ssok/bank/domain/transfer/dto/TransferWithdrawRequestDTO.java
+++ b/src/main/java/kr/ssok/bank/domain/transfer/dto/TransferWithdrawRequestDTO.java
@@ -13,4 +13,5 @@ public class TransferWithdrawRequestDTO {
     private CurrencyCode currencyCode; // 통화 코드
     private String counterAccount; // 입금 계좌
     private BankCode counterBankCode; // 입금 은행 코드
+    private Long messageCreatedAt; // 메세지 생성 시간
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#63 

## 📝 요약(Summary)

- 입/출금 requestDto에 messageCreatedAt 필드 추가
- TransferListerner에 로직 추가
- 에러코드 추가

## 📸스크린샷 (선택)
